### PR TITLE
[PLAT-949] Install golint globally

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 
 	if !installedInPath("golint") {
 		cmd := command.New("go", "get", "-u", "golang.org/x/lint/golint")
+		cmd.SetDir("/") // workaround for https://github.com/golang/go/issues/30515 to install the package globally
 
 		log.Infof("\nInstalling golint")
 		log.Donef("$ %s", cmd.PrintableCommandArgs())


### PR DESCRIPTION
* ensures that installing golint won't change go module dependencies